### PR TITLE
Changed production docker to use gunicorn. Upgraded requirements and …

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim
+FROM python:3.8-slim
 
 # Set the working directory in the container
 WORKDIR /app
@@ -13,7 +13,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the current directory contents into the container at /app
 COPY . /app/
 
-# Make port 8000 available to the world outside this container
-EXPOSE 8000
+# Make port 5000 available to the world outside this container
+EXPOSE 5000
 
-CMD ["gunicorn", "-w", "4", "-t", "60", "-b", "0.0.0.0:8000", "app:app"]
+# Define environment variable for Flask
+ENV FLASK_APP app.py
+
+# Run app.py when the container launches
+CMD ["flask", "run", "--host", "0.0.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-Flask==2.0.1
-requests==2.26.0
+Flask==3.0.0
+requests==2.31.0
+gunicorn==21.2.0


### PR DESCRIPTION
Hello!

Very cool project. I noticed when I spun up the image, it spat out a message about not using the built-in Flask web server in production. 

So I changed the Dockerfile over to use Gunicorn, upgraded the Python version to 3.11 (3.8 is EOL later this year), and upgraded the dependencies as well.

I moved over the existing Dockerfile to Dockerfile-dev and left it as is, though at the very least it should probably be upgraded to 3.11 soon. I do see the benefit for keeping it around for development work though.

Additional improvements that could be made in the future are multi-stage builds to further reduce the image size, as well as pairing Nginx in front of Gunicorn to proxy requests.

I did some rudimentary testing and it seems to work, but additional testing maybe required to verify my findings.

-Joe
